### PR TITLE
Add option to include openshift compatibility in quickstarts ToC

### DIFF
--- a/quickstart-documentation-plugin/pom.xml
+++ b/quickstart-documentation-plugin/pom.xml
@@ -34,6 +34,7 @@
         <version.org.apache.maven.maven-core>3.3.1</version.org.apache.maven.maven-core>
         <version.org.apache.maven.plugin-testing.maven-plugin-testing-harness>3.3.0</version.org.apache.maven.plugin-testing.maven-plugin-testing-harness>
         <version.org.apache.maven.plugin-tools>3.5</version.org.apache.maven.plugin-tools>
+        <version.org.asciidoctor.asciidoctorj>2.4.2</version.org.asciidoctor.asciidoctorj>
         <version.junit>4.12</version.junit>
         <version.dk.nykredit.jackson.dataformat>1.0.1</version.dk.nykredit.jackson.dataformat>
         <version.org.apache.httpcomponents>4.5.5</version.org.apache.httpcomponents>
@@ -194,7 +195,7 @@
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj</artifactId>
-            <version>1.5.6</version>
+            <version>${version.org.asciidoctor.asciidoctorj}</version>
         </dependency>
 
     </dependencies>

--- a/quickstart-documentation-plugin/src/main/java/org/wildfly/maven/plugins/quickstart/documentation/MetaData.java
+++ b/quickstart-documentation-plugin/src/main/java/org/wildfly/maven/plugins/quickstart/documentation/MetaData.java
@@ -15,8 +15,7 @@ import java.util.stream.Collectors;
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.Options;
 import org.asciidoctor.SafeMode;
-import org.asciidoctor.ast.DocumentHeader;
-import org.asciidoctor.ast.StructuredDocument;
+import org.asciidoctor.ast.Document;
 
 /**
  * @author Jason Porter <jporter@redhat.com>
@@ -35,16 +34,12 @@ public class MetaData {
 
     public static MetaData parseReadme(Path quickstartDir) throws IOException {
         Path path = quickstartDir.resolve("README.adoc");
-
         Asciidoctor asciidoctor = create();
         Options options = new Options();
         options.setSafe(SafeMode.UNSAFE);  //to enable includes
-        StructuredDocument doc = asciidoctor.readDocumentStructure(path.toFile(), options.map());
-
-        DocumentHeader header = doc.getHeader();
-
+        Document doc = asciidoctor.loadFile(path.toFile(), options.map());
         MetaData metaData = new MetaData(quickstartDir.getFileName().toString());
-        metaData.setAttributes(header.getAttributes());
+        metaData.setAttributes(doc.getAttributes());
         try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
             boolean shouldReadAbstract = false;
             for (; ; ) {
@@ -77,6 +72,8 @@ public class MetaData {
         }
         if (attributes.containsKey("technologies")) {
             technologies = attributes.get("technologies").toString().split(",");
+        } else {
+            technologies = new String[]{};
         }
         if (attributes.containsKey("level")) {
             level = attributes.get("level").toString().trim();

--- a/quickstart-documentation-plugin/src/main/java/org/wildfly/maven/plugins/quickstart/documentation/TOCMojo.java
+++ b/quickstart-documentation-plugin/src/main/java/org/wildfly/maven/plugins/quickstart/documentation/TOCMojo.java
@@ -39,14 +39,17 @@ public class TOCMojo extends AbstractMojo {
     @Parameter(defaultValue = "target/docs/README.adoc", required = true)
     protected String targetDocument;
 
+    @Parameter
+    protected boolean includeOpenshift;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         TOCGenerator generator = new TOCGenerator(Arrays.asList("target", "dist", "template", "guide"));
         Path root = rootDirectory.toPath();
         getLog().info("root directory: " + root);
+
         try {
-            generator.generate(root, replaceMarker, Paths.get(targetDocument));
+            generator.generate(root, replaceMarker, Paths.get(targetDocument), includeOpenshift);
         } catch (IOException e) {
             throw new MojoFailureException("Could not generate TOC", e);
         }


### PR DESCRIPTION
New feature for the EAP Quickstarts root README's table of quickstarts, indicate which quickstarts are compatible with OpenShift.

Also updates AsciidoctorJ, to get ridden of "WARNING: An illegal reflective access operation has occurred"
 
@bstansberry want to review this one? A new version of the QS Documention Plugin with such feature is needed for EAP7-1409 feature PR.
